### PR TITLE
Expand env variable for production

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -38,6 +38,11 @@ export default {
   plugins: [
     new ExtractTextPlugin("[name].css"),
     ...(isProduction ? [
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+        },
+      }),
       new webpack.optimize.UglifyJsPlugin({
         compress: {
           warnings: false


### PR DESCRIPTION
Webpack does not expand environment variables by default.
There are a lot of `if("production"!==n.env.NODE_ENV){...}` statements remaining in `public/assets/application.js`.

If webpack uses `DefinePlugin` and eliminates all environment variable checks,
the size of `public/assets/application.js` will be decreased to 428KB from 439KB.

Tested on node 6.2.1 and npm 3.9.3 on Windows 10.
Since `npm run build` is not executable on Windows due to `NODE_ENV=production`,
I executed `export NODE_ENV=production` and `./node_modules/.bin/webpack ...` instead.
